### PR TITLE
go-1388: add gradient to exported svg element

### DIFF
--- a/src/script/saveLoadEngine.js
+++ b/src/script/saveLoadEngine.js
@@ -47,6 +47,58 @@ function getSubSelectorTextFromXML(responseXML, selectorName, attributeName, att
   return value;
 }
 
+/**
+ * Escapes a string for use in a regular expression.  Taken from MDN:
+ * 
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping
+ * 
+ * @param {String} string 
+ * @returns 
+ */
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}
+
+/**
+ * Uses native browser functionalty to encode HTML entities within a string.
+ * 
+ * @param {String} string 
+ * @returns 
+ */
+function encodeHTMLEntities(string) {
+  let el = document.createElement('div');
+  el.textContent = string;
+  return el.innerHTML;
+}
+
+/**
+ * Converts a URI into a value which can be used in a regular expression
+ * 
+ * @param {String} uri 
+ * @returns 
+ */
+function uriAsRegex(uri) {
+  return escapeRegExp(
+    encodeHTMLEntities(uri)
+  );
+}
+
+/**
+ * Process the Canvas element to return SVG data.
+ * 
+ * @param {DOMElement} element 
+ */
+function canvasToSvg(element) {
+  var bbox = element.down().getBBox();
+
+  return element.innerHTML
+    .replace(/xmlns:xlink=".*?"/, '')
+    .replace(/width=".*?"/, '')
+    .replace(/height=".*?"/, '')
+    .replace(/viewBox=".*?"/, 'viewBox="' + bbox.x + ' ' + bbox.y + ' ' + bbox.width + ' ' + bbox.height + '" width="' + bbox.width + '" height="' + bbox.height + '" xmlns:xlink="http://www.w3.org/1999/xlink"')
+    .replaceAll(new RegExp(uriAsRegex(window.location.href), 'g'), '');
+}
+
 var SaveLoadEngine = Class.create( {
   _defaultSaveFunction: function(args) {
     var me = this;
@@ -198,13 +250,12 @@ var SaveLoadEngine = Class.create( {
     var backgroundPosition = background.nextSibling;
     var backgroundParent =  background.parentNode;
     backgroundParent.removeChild(background);
-    var bbox = image.down().getBBox();
     
     this._saveFunction({
       patientDataUrl: patientDataUrl,
       jsonData: jsonData,
       setSaveInProgress: this.setSaveInProgress,
-      svgData: image.innerHTML.replace(/xmlns:xlink=".*?"/, '').replace(/width=".*?"/, '').replace(/height=".*?"/, '').replace(/viewBox=".*?"/, 'viewBox="' + bbox.x + ' ' + bbox.y + ' ' + bbox.width + ' ' + bbox.height + '" width="' + bbox.width + '" height="' + bbox.height + '" xmlns:xlink="http://www.w3.org/1999/xlink"')
+      svgData: canvasToSvg(image)
     });
     backgroundParent.insertBefore(background, backgroundPosition);
   },


### PR DESCRIPTION
Remove references to the current page URL from the SVG, as these relate to element IDs rather than anchor points on the page.

This fixes a bug in the exported SVG data, where if displayed the nodes of the pedigree are transparent.  I'm not 100% sure, but I think @dconlan may have experienced the same bug.