### PR TITLE
Allow OpenPedigree to be run through Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:14
+
+# create the app directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# install any dependencies
+# we copy package*.json over to make use of docker's cached builds
+COPY package*.json .
+RUN npm install \
+    && npm cache clean --force
+
+# copy over the rest of the source code
+COPY . .
+
+# run the application and make it available outside the container
+CMD ["npm", "run", "start-docker"]
+EXPOSE 9000

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Open Pedigree is a robust browser-based genomic pedigree drawing solution using 
 
 ## Getting started
 
+### Command line
+
 Quickly get started with open pedigree on your computer:
 ```
 git clone git@github.com:phenotips/open-pedigree.git
@@ -40,7 +42,16 @@ npm start
 ```
 Open a browser to http://localhost:9000/
 
+### Docker
 
+You can also use the supplied Docker image to run the applicarion.  To get started:
+
+```
+git clone git@github.com:phenotips/open-pedigree.git
+cd open-pedigree
+docker build . -t open-pedigree
+docker run -p 9000:9000 -d open-pedigree
+```
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "src/app.js",
   "scripts": {
     "build": "webpack -p",
-    "start": "webpack-dev-server --mode=development --output-public-path=dist --watch"
+    "start": "webpack-dev-server --mode=development --output-public-path=dist --watch",
+    "start-docker": "webpack-dev-server --mode=production --output-public-path=dist --host=0.0.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Create a Dockerfile to allow OpenPedigree to be run within a Docker
container.  Update README to provide brief usage instructions.  Add
additional line to package.json for docker-triggered `start` command.

I tried using the Alpine linux version of the NodeJS image, but this
produced errors, so I've stuck with the stock version.