### PR TITLE
Restore mouse wheel zooming

### DIFF
--- a/src/script/view/workspace.js
+++ b/src/script/view/workspace.js
@@ -84,10 +84,9 @@ var Workspace = Class.create({
         } // Mozilla
 
         if (delta > 0) {
-          var x = $$('.zoom-out')[0];
-          $$('.zoom-out')[0].click();
+          me.__zoom['out'].click();
         } else {
-          $$('.zoom-in')[0].click();
+          me.__zoom['in'].click();
         }
       };
 


### PR DESCRIPTION
When handling mouse wheel, refer to `me.__zoom` rather than `$$('.zoom-in')[0]` and `$$('zoom-out')[0]`