### PR TITLE
Docker image doesn't build, fix COPY syntax and copy package.json and…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,12 @@ WORKDIR /usr/src/app
 
 # install any dependencies
 # we copy package*.json over to make use of docker's cached builds
-COPY package*.json .
+COPY package.json /usr/src/app
 RUN npm install \
     && npm cache clean --force
 
 # copy over the rest of the source code
-COPY . .
+COPY . /usr/src/app
 
 # run the application and make it available outside the container
 CMD ["npm", "run", "start-docker"]


### PR DESCRIPTION
Addresses [issue 61](https://github.com/phenotips/open-pedigree/issues/61).

The COPY statements now have destinations with a leading /, and point to /usr/src/app.
